### PR TITLE
Pretty-print bash plugin output 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .DS_Store
+venv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-trait"
-version = "0.1.59"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -68,15 +68,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -118,7 +118,7 @@ dependencies = [
  "async-trait",
  "json5",
  "lazy_static",
- "nom 7.1.1",
+ "nom 7.1.3",
  "pathdiff",
  "ron",
  "rust-ini",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
+checksum = "90d59d9acd2a682b4e40605a242f6670eaa58c5957471cbf85e8aa6a0b97a5e8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
+checksum = "ebfa40bda659dd5c864e65f4c9a2b0aff19bea56b017b9b77c73d3766a453a38"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -182,15 +182,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
+checksum = "457ce6757c5c70dc6ecdbda6925b958aae7f959bda7d8fb9bde889e34a09dc03"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
+checksum = "ebf883b7aacd7b2aeb2a7b338648ee19f57c140d4ee8e52c68979c6b2f7f2263"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adab1eaa3408fb7f0c777a73e7465fd5656136fc93b670eb6df3c88c2c1344e3"
+checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "instant"
@@ -323,15 +323,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
@@ -438,9 +438,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "ordered-multimap"
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
@@ -538,9 +538,9 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pest"
-version = "2.5.1"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
+checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.1"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
+checksum = "2ac3922aac69a40733080f53c1ce7f91dcf57e1a5f6c52f421fadec7fbdc4b69"
 dependencies = [
  "pest",
  "pest_generator",
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.1"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
+checksum = "d06646e185566b5961b4058dd107e0a7f56e77c3f484549fb119867773c0f202"
 dependencies = [
  "pest",
  "pest_meta",
@@ -571,13 +571,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.1"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
+checksum = "e6f60b2ba541577e2a0c307c8f39d1439108120eb7903adeb6497fa880c59616"
 dependencies = [
  "once_cell",
  "pest",
- "sha1",
+ "sha2",
 ]
 
 [[package]]
@@ -588,18 +588,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
+checksum = "06a3d8e8a46ab2738109347433cb7b96dffda2e4a218b03ef27090238886b147"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
+checksum = "75439f995d07ddfad42b192dfcf3bc66a7ecfd8b4a1f5f6f046aa5c2c5d7677d"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
+checksum = "839526a5c07a17ff44823679b68add4a58004de00512a95b6c1c98a6dcac0ee5"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -634,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94144a1266e236b1c932682136dc35a9dee8d3589728f68130c7c3861ef96b28"
+checksum = "bd44cf207476c6a9760c4653559be4f206efafb924d3e4cbf2721475fc0d6cc5"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
+checksum = "dc1f43d8e30460f36350d18631ccf85ded64c059829208fe680904c65bcd0a4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -657,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "scopeguard"
@@ -747,24 +747,24 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -783,10 +783,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.5"
+name = "sha2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -807,9 +807,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -818,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tempfile"
@@ -838,27 +838,27 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -878,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -899,9 +899,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-width"
@@ -911,9 +911,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unindent"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
+checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
 
 [[package]]
 name = "version_check"
@@ -935,9 +935,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -945,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -960,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -970,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -983,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "winapi"
@@ -1020,9 +1020,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1035,45 +1044,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 [dependencies]
 libloading = "0.5"
 config = "0.13.1"
-pyo3 = {"version" = "0.18.1"}
+pyo3 = {"version" = "0.18.1", features = ["auto-initialize"]}
 gag = "1.0.0"
 lazy_static = "1.4.0"
 iso8601-duration = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 [dependencies]
 libloading = "0.5"
 config = "0.13.1"
-pyo3 = {"version" = "0.17.3", features = ["auto-initialize"]}
+pyo3 = {"version" = "0.18.1"}
 gag = "1.0.0"
 lazy_static = "1.4.0"
 iso8601-duration = "0.1.0"

--- a/configs/timestamps.yml
+++ b/configs/timestamps.yml
@@ -1,4 +1,0 @@
-plugins:
-  - loop:
-      target: 01
-

--- a/configs/timestamps.yml
+++ b/configs/timestamps.yml
@@ -1,0 +1,4 @@
+plugins:
+  - loop:
+      target: 01
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod plug;
 mod settings;
 mod stdout_styling;
 mod intervals;
+mod plugin_logger;
 
 use settings::load_config;
 use plug::start_main_loop;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,18 @@
+mod intervals;
 mod plug;
+mod plugin_logger;
 mod settings;
 mod stdout_styling;
-mod intervals;
-mod plugin_logger;
 
-use settings::load_config;
 use plug::start_main_loop;
-
+use settings::load_config;
 
 fn main() {
     // get config path from args
-    let config_path = std::env::args().nth(1).or(Some("config.yml".to_string())).unwrap();
+    let config_path = std::env::args()
+        .nth(1)
+        .or(Some("config.yml".to_string()))
+        .unwrap();
     let config = load_config(&config_path);
     start_main_loop(&config)
 }

--- a/src/plug.rs
+++ b/src/plug.rs
@@ -31,7 +31,7 @@ pub enum PluginLanguage {
 }
 
 pub trait PluginInterface {
-    fn run(&self, config: &HashMap<String, String>) -> Result<(), String>;
+    fn run(&self, name: &str, config: &HashMap<String, String>) -> Result<(), String>;
 }
 
 
@@ -64,8 +64,8 @@ impl FromConfig<StartupMode> for StartupMode {
 
 
 fn call_plugin(name: &str, plugin: &CallablePlugin, config: &HashMap<String, String>) {
-    println!("{}", style_line(name.to_string(), "Running...".to_string()));
-    match plugin.run(&config) {
+    println!("{}", style_line(name, "Running..."));
+    match plugin.run(&name, &config) {
         Err(err) => panic!("Error while running plugin {}: {}", name, err),
         _ => {}
     };

--- a/src/plug.rs
+++ b/src/plug.rs
@@ -5,6 +5,7 @@ use python_plugin::load as load_py_plugin;
 use bash_plugin::load as load_sh_plugin;
 
 use std::thread::JoinHandle;
+use std::fmt::Display;
 use std::thread;
 use std::sync::Mutex;
 use std::path::PathBuf;
@@ -31,7 +32,7 @@ pub enum PluginLanguage {
 }
 
 pub trait PluginInterface {
-    fn run(&self, name: &str, config: &HashMap<String, String>) -> Result<(), String>;
+    fn run(&self, name: &str, config: &HashMap<String, String>) -> Result<Box<dyn Display>, String>;
 }
 
 
@@ -66,8 +67,8 @@ impl FromConfig<StartupMode> for StartupMode {
 fn call_plugin(name: &str, plugin: &CallablePlugin, config: &HashMap<String, String>) {
     println!("{}", style_line(name, "Running..."));
     match plugin.run(&name, &config) {
+        Ok(displayable) => println!("{}", style_line(name, displayable)),
         Err(err) => panic!("Error while running plugin {}: {}", name, err),
-        _ => {}
     };
 }
 

--- a/src/plug/bash_plugin.rs
+++ b/src/plug/bash_plugin.rs
@@ -1,10 +1,9 @@
-use std::process::{Command, Child, Stdio, ChildStdout};
-use std::path::{Path,PathBuf};
-use std::collections::HashMap;
-use crate::plug::{unwrap_home_path, PluginInterface, CallablePlugin, PLUGINS_PATH};
-use std::io::Read;
+use crate::plug::{unwrap_home_path, CallablePlugin, PluginInterface, PLUGINS_PATH};
 use chrono::Local;
-
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdout, Command, Stdio};
 
 struct BashCommand {
     executable: PathBuf,
@@ -31,36 +30,31 @@ fn log(line: &str) {
     println!("[{}] {}", Local::now().format("%Y-%m-%d %H:%M:%S"), line);
 }
 
-fn try_get_line(stdout: &mut ChildStdout, collected: &mut Vec<u8>) -> Option<String>{
+fn try_get_line(stdout: &mut ChildStdout, collected: &mut Vec<u8>) -> Option<String> {
     let bytebuff: &mut [u8; 1] = &mut [0; 1];
     match stdout.read_exact(bytebuff) {
         Ok(_) => {
             collected.push(bytebuff[0]);
-        },
+        }
         Err(_) => {
             // println!("Error: {}", e);
         }
     }
 
-    match detect_line(&collected) {
-        Some(string) => {
-            return Some(string);
-        }
-        None => None,
-    }
+    detect_line(&collected)
 }
 
 impl PluginInterface for BashCommand {
     fn run(&self, config: &HashMap<String, String>) -> Result<(), String> {
         // get a string of args and values from hashmap
         let mut child = Command::new("bash")
-             .envs(config)
-             .arg("-C")
-             .arg(self.executable.to_str().unwrap())
-             .stdout(Stdio::piped())
-             // .args(&args)
-             .spawn()
-             .expect("failed to start process {}");
+            .envs(config)
+            .arg("-C")
+            .arg(self.executable.to_str().unwrap())
+            .stdout(Stdio::piped())
+            // .args(&args)
+            .spawn()
+            .expect("failed to start process {}");
         let mut stdout = child.stdout.take().expect("Stdout is available");
 
         let mut status;
@@ -82,15 +76,18 @@ impl PluginInterface for BashCommand {
         let status = status.unwrap();
         let result: Result<String, String> = match status {
             Ok(code) => {
-                let msg = format!("{} command exited with code {}",self.executable.to_str().unwrap(), code);
+                let msg = format!(
+                    "{} command exited with code {}",
+                    self.executable.to_str().unwrap(),
+                    code
+                );
                 match code {
                     0 => Ok(msg),
-                    _ => Err(msg)
+                    _ => Err(msg),
                 }
-            },
+            }
             Err(msg) => Err(msg),
         };
-
 
         // print non-error result
         // return error message
@@ -104,14 +101,17 @@ impl PluginInterface for BashCommand {
 
 pub fn load(name: &str) -> Result<CallablePlugin, String> {
     let plugins_path = unwrap_home_path(PLUGINS_PATH);
-    let plugins_dirname = plugins_path.to_str().expect("Can't find home directory for the current user");
+    let plugins_dirname = plugins_path
+        .to_str()
+        .expect("Can't find home directory for the current user");
 
     let entrypoint_path = format!("{}/{}/run.sh", &plugins_dirname, name);
     let path_to_main = Path::new(&entrypoint_path);
 
     match path_to_main.exists() {
-        true => Ok(Box::new(BashCommand { executable : path_to_main.to_path_buf() })),
-        false => Err(format!("No main.py found for plugin: {}", name))
+        true => Ok(Box::new(BashCommand {
+            executable: path_to_main.to_path_buf(),
+        })),
+        false => Err(format!("No main.py found for plugin: {}", name)),
     }
 }
-

--- a/src/plug/bash_plugin.rs
+++ b/src/plug/bash_plugin.rs
@@ -1,17 +1,21 @@
 use crate::plug::{unwrap_home_path, CallablePlugin, PluginInterface, PLUGINS_PATH};
+use crate::plugin_logger::PluginLogger;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use crate::plugin_logger::PluginLogger;
 
 struct BashCommand {
     executable: PathBuf,
 }
 
 impl PluginInterface for BashCommand {
-    fn run(&self, name: &str, config: &HashMap<String, String>) -> Result<Box<dyn Display>, String> {
+    fn run(
+        &self,
+        name: &str,
+        config: &HashMap<String, String>,
+    ) -> Result<Box<dyn Display>, String> {
         // get a string of args and values from hashmap
         let mut child = Command::new("bash")
             .envs(config)
@@ -23,14 +27,15 @@ impl PluginInterface for BashCommand {
             .expect("failed to start process {}");
 
         // Wrap streams into a buffered stream, then box it
-        let stdout = Box::new(BufReader::new(child.stdout.take().expect("Stdout is unavailable")));
-        let stderr = Box::new(BufReader::new(child.stderr.take().expect("Stderr is unavailable")));
+        let stdout = Box::new(BufReader::new(
+            child.stdout.take().expect("Stdout is unavailable"),
+        ));
+        let stderr = Box::new(BufReader::new(
+            child.stderr.take().expect("Stderr is unavailable"),
+        ));
 
         // Init logger
-        let plugin_logger = PluginLogger::new(
-            name,
-            vec![stdout, stderr]
-        );
+        let plugin_logger = PluginLogger::new(name, vec![stdout, stderr]);
 
         // Run the plugin
         let status = child.wait();

--- a/src/plug/bash_plugin.rs
+++ b/src/plug/bash_plugin.rs
@@ -1,27 +1,104 @@
-use std::process::Command;
+use std::process::{Command, Child, Stdio, ChildStdout};
 use std::path::{Path,PathBuf};
 use std::collections::HashMap;
 use crate::plug::{unwrap_home_path, PluginInterface, CallablePlugin, PLUGINS_PATH};
+use std::io::Read;
+use chrono::Local;
 
 
 struct BashCommand {
     executable: PathBuf,
 }
 
+fn get_process_status(child: &mut Child) -> Option<Result<i32, String>> {
+    // Checks the exit code of a process, and returns None if it is still running.
+    // If there is an error, it returns the error
+    match child.try_wait() {
+        // -1 === process was killed by a signal
+        Ok(Some(status)) => Some(Ok(status.code().unwrap_or(-1))),
+        Err(msg) => Some(Err(msg.to_string())),
+        Ok(None) => None,
+    }
+}
+fn detect_line(bytes: &Vec<u8>) -> Option<String> {
+    if bytes.len() > 0 && bytes[bytes.len() - 1] == b'\n' {
+        return Some(String::from_utf8(bytes[..bytes.len() - 1].to_vec()).unwrap());
+    }
+    None
+}
+
+fn log(line: &str) {
+    println!("[{}] {}", Local::now().format("%Y-%m-%d %H:%M:%S"), line);
+}
+
+fn try_get_line(stdout: &mut ChildStdout, collected: &mut Vec<u8>) -> Option<String>{
+    let bytebuff: &mut [u8; 1] = &mut [0; 1];
+    match stdout.read_exact(bytebuff) {
+        Ok(_) => {
+            collected.push(bytebuff[0]);
+        },
+        Err(_) => {
+            // println!("Error: {}", e);
+        }
+    }
+
+    match detect_line(&collected) {
+        Some(string) => {
+            return Some(string);
+        }
+        None => None,
+    }
+}
 
 impl PluginInterface for BashCommand {
     fn run(&self, config: &HashMap<String, String>) -> Result<(), String> {
         // get a string of args and values from hashmap
-        let output = Command::new("bash")
+        let mut child = Command::new("bash")
              .envs(config)
              .arg("-C")
              .arg(self.executable.to_str().unwrap())
+             .stdout(Stdio::piped())
              // .args(&args)
-             .output()
-             .expect("failed to execute process {}");
+             .spawn()
+             .expect("failed to start process {}");
+        let mut stdout = child.stdout.take().expect("Stdout is available");
 
-        println!("{}", String::from_utf8(output.stdout).unwrap());
-        Ok(())
+        let mut status;
+        let mut line: Vec<u8> = vec![];
+
+        loop {
+            match try_get_line(&mut stdout, &mut line) {
+                Some(string) => {
+                    log(&string);
+                    line = vec![];
+                }
+                None => {}
+            }
+            status = get_process_status(&mut child);
+            if let Some(_) = status {
+                break;
+            }
+        }
+        let status = status.unwrap();
+        let result: Result<String, String> = match status {
+            Ok(code) => {
+                let msg = format!("{} command exited with code {}",self.executable.to_str().unwrap(), code);
+                match code {
+                    0 => Ok(msg),
+                    _ => Err(msg)
+                }
+            },
+            Err(msg) => Err(msg),
+        };
+
+
+        // print non-error result
+        // return error message
+        match &result {
+            Ok(msg) => println!("{}", msg),
+            _ => {}
+        }
+        result.map(|_| ())
     }
 }
 

--- a/src/plug/python_plugin.rs
+++ b/src/plug/python_plugin.rs
@@ -1,30 +1,33 @@
-use std::fs;
-use std::fmt::Display;
-use std::path::Path;
-use std::collections::HashMap;
+use crate::plug::{unwrap_home_path, CallablePlugin, PluginInterface, PLUGINS_PATH};
 use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
-use pyo3::types::{PyModule, PyList};
-use crate::plug::{unwrap_home_path, PluginInterface, CallablePlugin, PLUGINS_PATH};
-
+use pyo3::types::{PyList, PyModule};
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::fs;
+use std::path::Path;
 
 impl PluginInterface for pyo3::Py<PyAny> {
-    fn run(&self, name: &str, config: &HashMap<String, String>) -> Result<Box<dyn Display>, String> {
+    fn run(
+        &self,
+        name: &str,
+        config: &HashMap<String, String>,
+    ) -> Result<Box<dyn Display>, String> {
         let mut pyconfig = HashMap::new();
         pyconfig.insert("config", &config);
-        let result = Python::with_gil(|py| {
-            self.call(py, (), Some(pyconfig.into_py_dict(py)))
-        });
+        let result = Python::with_gil(|py| self.call(py, (), Some(pyconfig.into_py_dict(py))));
         match result {
             Ok(_) => Ok(Box::new(format!("{} finished execution", &name))),
-            Err(err) => Err(format!("{}", err))
+            Err(err) => Err(format!("{}", err)),
         }
     }
 }
 
 pub fn load(name: &str) -> Result<CallablePlugin, String> {
     let plugins_path = unwrap_home_path(PLUGINS_PATH);
-    let plugins_dirname = plugins_path.to_str().expect("Can't find home directory for the current user");
+    let plugins_dirname = plugins_path
+        .to_str()
+        .expect("Can't find home directory for the current user");
 
     let entrypoint_path = format!("{}/{}/main.py", &plugins_dirname, name);
     let path_to_main = Path::new(&entrypoint_path);
@@ -36,25 +39,32 @@ pub fn load(name: &str) -> Result<CallablePlugin, String> {
     match fs::read_to_string(&path_to_main) {
         Ok(code) => {
             let app = Python::with_gil(|py| {
-                let syspath: &PyList = py.import("sys").expect("Python can't import sys module. Nobody knows why")
-                    .getattr("path").unwrap()
-                    .downcast::<PyList>().expect("Somehow sys.path is not a valid pyhon list");
+                let syspath: &PyList = py
+                    .import("sys")
+                    .expect("Python can't import sys module. Nobody knows why")
+                    .getattr("path")
+                    .unwrap()
+                    .downcast::<PyList>()
+                    .expect("Somehow sys.path is not a valid pyhon list");
 
-                syspath.insert(0, &path_to_main).expect("Can't insert to Python path");
+                syspath
+                    .insert(0, &path_to_main)
+                    .expect("Can't insert to Python path");
 
                 let app: Py<PyAny> = PyModule::from_code(py, &code, "", "")
                     .expect(&format!("Can't find main.py for plugin {}", name))
                     .getattr("run")
-                    .expect(&format!("Can't find run function in main.py for plugin {}", name))
+                    .expect(&format!(
+                        "Can't find run function in main.py for plugin {}",
+                        name
+                    ))
                     .into();
                 return app;
-
             });
             return Ok(Box::new(app) as CallablePlugin);
-        },
+        }
         Err(_) => {
             return Err("Could not read main.py code".to_string());
         }
     }
 }
-

--- a/src/plug/python_plugin.rs
+++ b/src/plug/python_plugin.rs
@@ -8,10 +8,13 @@ use crate::plug::{unwrap_home_path, PluginInterface, CallablePlugin, PLUGINS_PAT
 
 
 impl PluginInterface for pyo3::Py<PyAny> {
-    fn run(&self, config: &HashMap<String, String>) -> Result<(), String> {
+    fn run(&self, name: &str, config: &HashMap<String, String>) -> Result<(), String> {
         let mut pyconfig = HashMap::new();
         pyconfig.insert("config", &config);
-        match Python::with_gil(|py| self.call(py, (), Some(pyconfig.into_py_dict(py)))) {
+        let result = Python::with_gil(|py| {
+            self.call(py, (), Some(pyconfig.into_py_dict(py)))
+        });
+        match result {
             Ok(_) => Ok(()),
             Err(err) => Err(format!("{}", err))
         }

--- a/src/plug/python_plugin.rs
+++ b/src/plug/python_plugin.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::fmt::Display;
 use std::path::Path;
 use std::collections::HashMap;
 use pyo3::prelude::*;
@@ -8,14 +9,14 @@ use crate::plug::{unwrap_home_path, PluginInterface, CallablePlugin, PLUGINS_PAT
 
 
 impl PluginInterface for pyo3::Py<PyAny> {
-    fn run(&self, name: &str, config: &HashMap<String, String>) -> Result<(), String> {
+    fn run(&self, name: &str, config: &HashMap<String, String>) -> Result<Box<dyn Display>, String> {
         let mut pyconfig = HashMap::new();
         pyconfig.insert("config", &config);
         let result = Python::with_gil(|py| {
             self.call(py, (), Some(pyconfig.into_py_dict(py)))
         });
         match result {
-            Ok(_) => Ok(()),
+            Ok(_) => Ok(Box::new(format!("{} finished execution", &name))),
             Err(err) => Err(format!("{}", err))
         }
     }

--- a/src/plugin_logger.rs
+++ b/src/plugin_logger.rs
@@ -20,11 +20,10 @@ impl PluginLogger {
     /// Immediately starts reading from streams
     pub fn new(
         plug_name: &str,
-        stopper: AtomicBool,
         streams: Vec<Box<dyn BufRead + Send>>
     ) -> PluginLogger {
         let mut routines: Vec<JoinHandle<()>> = Vec::new();
-        let stopper = Arc::new(stopper);
+        let stopper = Arc::new(AtomicBool::new(false));
 
         for stream in streams {
             let name_copy = plug_name.clone().to_string();

--- a/src/plugin_logger.rs
+++ b/src/plugin_logger.rs
@@ -1,0 +1,63 @@
+#![allow(dead_code)]
+use chrono::Local;
+use std::io::BufRead;
+use std::thread::{self, JoinHandle};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+
+fn log(line: &str, plug_name: &str) {
+    println!("[{}] [{}] {}", plug_name, Local::now().format("%Y-%m-%d %H:%M:%S"), line);
+}
+
+pub struct PluginLogger {
+    stopper: Arc<AtomicBool>,
+    routines: Vec<JoinHandle<()>>
+}
+
+impl PluginLogger {
+    /// Creates an instance of `PluginLogger`
+    /// Immediately starts reading from streams
+    pub fn new(
+        plug_name: &str,
+        stopper: AtomicBool,
+        streams: Vec<Box<dyn BufRead + Send>>
+    ) -> PluginLogger {
+        let mut routines: Vec<JoinHandle<()>> = Vec::new();
+        let stopper = Arc::new(stopper);
+
+        for stream in streams {
+            let name_copy = plug_name.clone().to_string();
+            let stopper = stopper.clone();
+            let handler = thread::spawn(move|| stream_logger(&name_copy, stream, stopper, log));
+            routines.push(handler);
+        }
+
+        return Self {stopper, routines}
+    }
+
+    pub fn stop(self) {
+        self.stopper.store(true, Ordering::Relaxed);
+        for routine in self.routines {
+            routine.join().unwrap();
+        };
+    }
+}
+
+
+fn stream_logger<F>(plug_name: &str, stream: Box<dyn BufRead>, stop_event: Arc<AtomicBool>, logger: F)
+where F: Fn(&str, &str)
+{
+    for line in stream.lines() {
+        match line {
+            Ok(line) if line.len() > 0 => logger(&line, plug_name),
+            Err(e) => println!("Cannot read data: {:?}", e),
+            _ => {},
+        }
+        if stop_event.load(Ordering::Relaxed) {
+            break;
+        }
+    }
+}
+
+

--- a/src/plugin_logger.rs
+++ b/src/plugin_logger.rs
@@ -1,62 +1,65 @@
 #![allow(dead_code)]
 use chrono::Local;
 use std::io::BufRead;
-use std::thread::{self, JoinHandle};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
 
 fn log(line: &str, plug_name: &str) {
-    println!("[{}] [{}] {}", plug_name, Local::now().format("%Y-%m-%d %H:%M:%S"), line);
+    println!(
+        "[{}] [{}] {}",
+        plug_name,
+        Local::now().format("%Y-%m-%d %H:%M:%S"),
+        line
+    );
 }
 
 pub struct PluginLogger {
     stopper: Arc<AtomicBool>,
-    routines: Vec<JoinHandle<()>>
+    routines: Vec<JoinHandle<()>>,
 }
 
 impl PluginLogger {
     /// Creates an instance of `PluginLogger`
     /// Immediately starts reading from streams
-    pub fn new(
-        plug_name: &str,
-        streams: Vec<Box<dyn BufRead + Send>>
-    ) -> PluginLogger {
+    pub fn new(plug_name: &str, streams: Vec<Box<dyn BufRead + Send>>) -> PluginLogger {
         let mut routines: Vec<JoinHandle<()>> = Vec::new();
         let stopper = Arc::new(AtomicBool::new(false));
 
         for stream in streams {
             let name_copy = plug_name.clone().to_string();
             let stopper = stopper.clone();
-            let handler = thread::spawn(move|| stream_logger(&name_copy, stream, stopper, log));
+            let handler = thread::spawn(move || stream_logger(&name_copy, stream, stopper, log));
             routines.push(handler);
         }
 
-        return Self {stopper, routines}
+        return Self { stopper, routines };
     }
 
     pub fn stop(self) {
         self.stopper.store(true, Ordering::Relaxed);
         for routine in self.routines {
             routine.join().unwrap();
-        };
+        }
     }
 }
 
-
-fn stream_logger<F>(plug_name: &str, stream: Box<dyn BufRead>, stop_event: Arc<AtomicBool>, logger: F)
-where F: Fn(&str, &str)
+fn stream_logger<F>(
+    plug_name: &str,
+    stream: Box<dyn BufRead>,
+    stop_event: Arc<AtomicBool>,
+    logger: F,
+) where
+    F: Fn(&str, &str),
 {
     for line in stream.lines() {
         match line {
             Ok(line) if line.len() > 0 => logger(&line, plug_name),
             Err(e) => println!("Cannot read data: {:?}", e),
-            _ => {},
+            _ => {}
         }
         if stop_event.load(Ordering::Relaxed) {
             break;
         }
     }
 }
-
-

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -20,7 +20,7 @@ pub fn load_config(path: &str) -> PluginsConfig {
 
     return settings
         .try_deserialize::<HashMap<String, PluginsConfig>>()
-        .unwrap()
+        .expect("Config file is valid")
         .get("plugins")
         .expect("Plugins config found")
         .to_vec();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,7 +7,6 @@ pub trait FromConfig<T> {
     fn from_config(config: &HashMap<String, String>) -> Result<T, String>;
 }
 
-
 pub fn load_config(path: &str) -> PluginsConfig {
     let settings = Config::builder()
         // Add in `./Settings.toml`

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -20,8 +20,8 @@ pub fn load_config(path: &str) -> PluginsConfig {
 
     return settings
         .try_deserialize::<HashMap<String, PluginsConfig>>()
-        .expect("Config file is valid")
+        .expect("Config file is not valid")
         .get("plugins")
-        .expect("Plugins config found")
+        .expect("Plugins config not found")
         .to_vec();
 }

--- a/src/stdout_styling.rs
+++ b/src/stdout_styling.rs
@@ -59,10 +59,10 @@ fn get_associated_color(plugname: &str) -> Color {
     }
 }
 
-pub fn style_line(plugname: String, message: String) -> String {
-    let name_part = get_plugname_format(&plugname);
+pub fn style_line(plugname: &str, message: &str) -> String {
+    let name_part = get_plugname_format(plugname);
     let dt_part = get_datetime_format();
     let line = format!("{}\t{}\t{}", name_part, dt_part, message);
-    let line = color_line(&line, &get_associated_color(&plugname));
+    let line = color_line(&line, &get_associated_color(plugname));
     line.to_string()
 }

--- a/src/stdout_styling.rs
+++ b/src/stdout_styling.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::sync::Mutex;
 use std::collections::HashMap;
 use std::ops::{Range, Sub};
@@ -59,7 +60,7 @@ fn get_associated_color(plugname: &str) -> Color {
     }
 }
 
-pub fn style_line(plugname: &str, message: &str) -> String {
+pub fn style_line(plugname: &str, message: impl Display) -> String {
     let name_part = get_plugname_format(plugname);
     let dt_part = get_datetime_format();
     let line = format!("{}\t{}\t{}", name_part, dt_part, message);

--- a/src/stdout_styling.rs
+++ b/src/stdout_styling.rs
@@ -1,8 +1,8 @@
-use std::fmt::Display;
-use std::sync::Mutex;
-use std::collections::HashMap;
-use std::ops::{Range, Sub};
 use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::ops::{Range, Sub};
+use std::sync::Mutex;
 use std::time::SystemTime;
 
 use lazy_static::lazy_static;
@@ -20,8 +20,7 @@ trait Diff<T> {
 }
 
 impl<T: Sub<Output = T> + Copy> Diff<T> for Range<T> {
-    fn get_diff(&self) -> T
-    {
+    fn get_diff(&self) -> T {
         self.end - self.start
     }
 }
@@ -52,7 +51,8 @@ fn get_associated_color(plugname: &str) -> Color {
     match color_mapping.get(plugname) {
         Some(color) => color.to_string(),
         None => {
-            let ansi_code = PALETTE_RANGE.get_diff() - color_mapping.len() as u8 % PALETTE_RANGE.get_diff();
+            let ansi_code =
+                PALETTE_RANGE.get_diff() - color_mapping.len() as u8 % PALETTE_RANGE.get_diff();
             let color = format!("38;5;{}", ansi_code);
             color_mapping.insert(plugname.to_string(), color.to_string());
             color.to_string()


### PR DESCRIPTION
resolves #6

- [x] Now parent process is **not** blocked until child process exits
- [x] Logic to read child process' stdout and print it with timestamp was added
- [x] Read from stderr is implemented

What is out of the scope of the implementation
- Same functionality for python plugin. Moved to https://github.com/subatiq/kittypaws/issues/14